### PR TITLE
Add Tromp-Taylor ruleset with legal self-captures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Project exclude paths
+__pycache__
 
 # CLion created directories
 /.idea/

--- a/src/Game/GoComponents.cpp
+++ b/src/Game/GoComponents.cpp
@@ -12,6 +12,7 @@ namespace sente {
         default:
         case CHINESE:
         case OTHER:
+        case TROMP_TAYLOR:
             return 7.5;
         case JAPANESE:
         case KOREAN:
@@ -29,8 +30,9 @@ namespace sente {
         }
         else if (ruleString == "korean" or ruleString == "korea"){
             return KOREAN;
-        }
-        else {
+        } else if (ruleString == "tromp-taylor") {
+            return TROMP_TAYLOR;
+        } else {
             return OTHER;
         }
     }

--- a/src/Game/GoComponents.h
+++ b/src/Game/GoComponents.h
@@ -17,6 +17,7 @@ namespace sente {
         CHINESE,
         JAPANESE,
         KOREAN,
+        TROMP_TAYLOR,
         OTHER
     };
 

--- a/src/Game/GoGame.cpp
+++ b/src/Game/GoGame.cpp
@@ -61,6 +61,9 @@ namespace sente {
             case KOREAN:
                 rootNode.setProperty(SGF::RU, {"Korean"});
                 break;
+            case TROMP_TAYLOR:
+                rootNode.setProperty(SGF::RU, {"Tromp-Taylor"});
+                break;
         }
 
         gameTree = utils::Tree<SGF::SGFNode>(rootNode);
@@ -214,7 +217,7 @@ namespace sente {
             if (not isCorrectColor(move)){
                 throw utils::IllegalMoveException(utils::WRONG_COLOR, move);
             }
-            if (not isNotSelfCapture(move)){
+            if (rules != TROMP_TAYLOR and not isNotSelfCapture(move)){
                 throw utils::IllegalMoveException(utils::SELF_CAPTURE, move);
             }
             if (not isNotKoPoint(move)){

--- a/src/Game/GoGame.cpp
+++ b/src/Game/GoGame.cpp
@@ -148,7 +148,7 @@ namespace sente {
         // std::cout << "passed isOnBoard" << std::endl;
         bool isEmpty = board->getStone(move.getVertex()) == EMPTY;
         // std::cout << "passed isEmpty" << std::endl;
-        bool notSelfCapture = isNotSelfCapture(move);
+        bool notSelfCapture = rules == TROMP_TAYLOR or isNotSelfCapture(move);
         // std::cout << "passed isNotSelfCapture" << std::endl;
         bool notKoPoint = isNotKoPoint(move);
         // std::cout << "passed isNotKoPoint" << std::endl;
@@ -217,7 +217,7 @@ namespace sente {
             if (not isCorrectColor(move)){
                 throw utils::IllegalMoveException(utils::WRONG_COLOR, move);
             }
-            if (rules != TROMP_TAYLOR and not isNotSelfCapture(move)){
+            if (not isNotSelfCapture(move)){
                 throw utils::IllegalMoveException(utils::SELF_CAPTURE, move);
             }
             if (not isNotKoPoint(move)){
@@ -251,7 +251,7 @@ namespace sente {
         // std::cout << "passed isOnBoard" << std::endl;
         bool isEmpty = board->getStone(move.getVertex()) == EMPTY;
         // std::cout << "passed isEmpty" << std::endl;
-        bool notSelfCapture = isNotSelfCapture(move);
+        bool notSelfCapture = rules == TROMP_TAYLOR or isNotSelfCapture(move);
         // std::cout << "passed isNotSelfCapture" << std::endl;
         bool notKoPoint = isNotKoPoint(move);
 

--- a/src/Game/GoGame.cpp
+++ b/src/Game/GoGame.cpp
@@ -879,6 +879,13 @@ namespace sente {
             }
         }
 
+        // Handle legal self-captures under Tromp-Taylor rules
+        if (rules == TROMP_TAYLOR and not isNotSelfCapture(move)) {
+            // erase the item
+            groups.erase(move);
+            board->captureStone(move);
+            capturedStones[gameTree.getDepth()].insert(move);
+        }
     }
 
     bool GoGame::isCorrectColor(const Move &move) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -84,6 +84,9 @@ PYBIND11_MODULE(sente, module){
             .value("KOREAN", sente::Rules::KOREAN, R"pbdoc(
             The `Korean rules <https://senseis.xmp.net/?KoreanRules>`_ for go.
         )pbdoc")
+            .value("TROMP_TAYLOR", sente::Rules::KOREAN, R"pbdoc(
+            The `Tromp-Taylor rules <https://senseis.xmp.net/?TrompTaylorRules>`_ for go.
+        )pbdoc")
         .export_values();
 
     py::class_<sente::Vertex>(module, "Vertex", R"pbdoc(

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -84,7 +84,7 @@ PYBIND11_MODULE(sente, module){
             .value("KOREAN", sente::Rules::KOREAN, R"pbdoc(
             The `Korean rules <https://senseis.xmp.net/?KoreanRules>`_ for go.
         )pbdoc")
-            .value("TROMP_TAYLOR", sente::Rules::KOREAN, R"pbdoc(
+            .value("TROMP_TAYLOR", sente::Rules::TROMP_TAYLOR, R"pbdoc(
             The `Tromp-Taylor rules <https://senseis.xmp.net/?TrompTaylorRules>`_ for go.
         )pbdoc")
         .export_values();

--- a/tests/test_move_legality.py
+++ b/tests/test_move_legality.py
@@ -517,6 +517,9 @@ class IllegalMoveThrowsException(TestCase):
             else:
                 game.play(1, 1, sente.stone.WHITE)
 
+                # Make sure the self-captured stone is actually captured
+                self.assertTrue(game.get_board().get_stone(1, 1) == sente.stone.EMPTY)
+
     def test_group_self_capture(self):
         """
 
@@ -544,6 +547,9 @@ class IllegalMoveThrowsException(TestCase):
                     game.play(1, 1)
             else:
                 game.play(1, 1)
+
+                # Make sure the self-captured stone is actually captured
+                self.assertTrue(game.get_board().get_stone(1, 1) == sente.stone.EMPTY)
 
     def test_ko(self):
         """

--- a/tests/test_move_legality.py
+++ b/tests/test_move_legality.py
@@ -264,42 +264,54 @@ class TestLegalMove(TestCase):
     def test_self_capture(self):
         """
 
-        checks to see if a self-capture move is illegal
+        checks to see if a self-capture move is illegal unless we're using
+        Tromp-Taylor rules
 
         :return:
         """
 
-        game = sente.Game()
+        for ruleset in (sente.rules.CHINESE, sente.rules.TROMP_TAYLOR):
+            game = sente.Game(19, ruleset)
 
-        game.play(1, 2, sente.stone.BLACK)
-        game.play(19, 19, sente.stone.WHITE)
+            game.play(1, 2, sente.stone.BLACK)
+            game.play(19, 19, sente.stone.WHITE)
 
-        game.play(2, 1, sente.stone.BLACK)
+            game.play(2, 1, sente.stone.BLACK)
 
-        self.assertFalse(game.is_legal(1, 1, sente.stone.WHITE))
+            legal = game.is_legal(1, 1, sente.stone.WHITE)
+            if ruleset == sente.rules.CHINESE:
+                self.assertFalse(legal)
+            else:
+                self.assertTrue(legal)
 
     def test_group_self_capture(self):
         """
 
         checks to see self capture moves are illegal for groups of stones
+        unless we're using Tromp-Taylor rules
 
         :return:
         """
 
-        game = sente.Game()
+        for ruleset in (sente.rules.CHINESE, sente.rules.TROMP_TAYLOR):
+            game = sente.Game(19, ruleset)
 
-        game.play(1, 3, sente.stone.BLACK)
-        game.play(1, 2, sente.stone.WHITE)
+            game.play(1, 3, sente.stone.BLACK)
+            game.play(1, 2, sente.stone.WHITE)
 
-        game.play(2, 3, sente.stone.BLACK)
-        game.play(2, 2, sente.stone.WHITE)
+            game.play(2, 3, sente.stone.BLACK)
+            game.play(2, 2, sente.stone.WHITE)
 
-        game.play(3, 2, sente.stone.BLACK)
-        game.play(2, 1, sente.stone.WHITE)
+            game.play(3, 2, sente.stone.BLACK)
+            game.play(2, 1, sente.stone.WHITE)
 
-        game.play(3, 1, sente.stone.BLACK)
+            game.play(3, 1, sente.stone.BLACK)
 
-        self.assertFalse(game.is_legal(1, 1))
+            legal = game.is_legal(1, 1)
+            if ruleset == sente.rules.CHINESE:
+                self.assertFalse(legal)
+            else:
+                self.assertTrue(legal)
 
     def test_empty_triangle_liberties(self):
         """
@@ -491,15 +503,19 @@ class IllegalMoveThrowsException(TestCase):
         :return:
         """
 
-        game = sente.Game()
+        for ruleset in (sente.rules.CHINESE, sente.rules.TROMP_TAYLOR):
+            game = sente.Game(19, ruleset)
 
-        game.play(1, 2, sente.stone.BLACK)
-        game.play(19, 19, sente.stone.WHITE)
+            game.play(1, 2, sente.stone.BLACK)
+            game.play(19, 19, sente.stone.WHITE)
 
-        game.play(2, 1, sente.stone.BLACK)
+            game.play(2, 1, sente.stone.BLACK)
 
-        with self.assertRaises(sente.exceptions.IllegalMoveException):
-            game.play(1, 1, sente.stone.WHITE)
+            if ruleset == sente.rules.CHINESE:
+                with self.assertRaises(sente.exceptions.IllegalMoveException):
+                    game.play(1, 1, sente.stone.WHITE)
+            else:
+                game.play(1, 1, sente.stone.WHITE)
 
     def test_group_self_capture(self):
         """
@@ -509,21 +525,25 @@ class IllegalMoveThrowsException(TestCase):
         :return:
         """
 
-        game = sente.Game()
+        for ruleset in (sente.rules.CHINESE, sente.rules.TROMP_TAYLOR):
+            game = sente.Game(19, ruleset)
 
-        game.play(1, 3, sente.stone.BLACK)
-        game.play(1, 2, sente.stone.WHITE)
+            game.play(1, 3, sente.stone.BLACK)
+            game.play(1, 2, sente.stone.WHITE)
 
-        game.play(2, 3, sente.stone.BLACK)
-        game.play(2, 2, sente.stone.WHITE)
+            game.play(2, 3, sente.stone.BLACK)
+            game.play(2, 2, sente.stone.WHITE)
 
-        game.play(3, 2, sente.stone.BLACK)
-        game.play(2, 1, sente.stone.WHITE)
+            game.play(3, 2, sente.stone.BLACK)
+            game.play(2, 1, sente.stone.WHITE)
 
-        game.play(3, 1, sente.stone.BLACK)
+            game.play(3, 1, sente.stone.BLACK)
 
-        with self.assertRaises(sente.exceptions.IllegalMoveException):
-            game.play(1, 1)
+            if ruleset == sente.rules.CHINESE:
+                with self.assertRaises(sente.exceptions.IllegalMoveException):
+                    game.play(1, 1)
+            else:
+                game.play(1, 1)
 
     def test_ko(self):
         """


### PR DESCRIPTION
This PR adds a new `TROMP_TAYLOR` ruleset in the `sente.rules` enumeration, which behaves like the existing `CHINESE` ruleset except that self-captures are allowed. I've added a bit of extra logic to the self-capture tests in `test_move_legality.py` to make sure self-captures are allowed if and **only** if the ruleset is `TROMP_TAYLOR`.

This is arguably a useful feature for computer Go because many computer Go bots (such as [KataGo](https://arxiv.org/pdf/1902.10565.pdf); see code [here](https://github.com/lightvector/KataGo)) are trained using [Tromp-Taylor rules](https://senseis.xmp.net/?TrompTaylorRules).